### PR TITLE
Fix the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,61 @@
 /vendor/
 /composer.phar
 /.idea
+
+### OSX template
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+### Windows template
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: php
 
-php: [5.3.3, 5.3, 5.4, 5.5]
+php:
+  - '5.4'
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - hhvm
+  - nightly
 
 before_script:
   - composer self-update
-  - composer install --prefer-source
+  - composer install
 
 script:
   - bin/phpspec run


### PR DESCRIPTION
This will fix the build.

Currently we are testing against very old versions of PHP that are not
listed as supported by travis. This should remove very old versions, but
also add newer versions to ensure our users have confidence that the code
still works.