### PR TITLE
Switch to using Semver tag for dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "purplebooth/twig-htmlstrip",
     "description": "Convert a small subset of html into something reasonable you can put in plain text email, or SMS.",
     "require": {
-        "twig/twig": ">=1.12"
+        "twig/twig": "^1.12.0"
     },
     "require-dev": {
         "phpspec/phpspec": "2.0.*@dev"


### PR DESCRIPTION
Semver will allow us to more accurately restrict us from automatically
upgrading to the upcoming BC breaking twig 2.0 release, saving our users
some pain.