### PR TITLE
Move coveralls to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
     "description": "Convert a small subset of html into something reasonable you can put in plain text email, or SMS.",
     "require": {
         "twig/twig": "^1.12.0",
-        "purplebooth/htmlstrip": "^1.0.0",
-        "satooshi/php-coveralls": "^1.0"
+        "purplebooth/htmlstrip": "^1.0.0"
     },
     "require-dev": {
         "phpspec/phpspec": "2.0.*@dev",
         "henrikbjorn/phpspec-code-coverage": "^2.1",
-        "sllh/php-cs-fixer-styleci-bridge": "^2.1"
+        "sllh/php-cs-fixer-styleci-bridge": "^2.1",
+        "satooshi/php-coveralls": "^1.0"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
Currently coveralls is a main dependency that our downstream clients
have to install. This will move the dependency to dev so our downstream
clients don't have this dependency.

Fixes #23